### PR TITLE
Remove teacher load caps

### DIFF
--- a/src/export_all_to_excel.py
+++ b/src/export_all_to_excel.py
@@ -52,7 +52,7 @@ def export_all_to_excel(filename: str,
 
     # ----- Лист: сводка по учителям -----
     ws_teachers = wb.create_sheet("Учителя")
-    header = ["Учитель", "Всего", "Лимит", "Среднее/день"] + data.days
+    header = ["Учитель", "Всего", "Среднее/день"] + data.days
     ws_teachers.append(header)
     for t in data.teachers:
         total = 0
@@ -74,7 +74,7 @@ def export_all_to_excel(filename: str,
                         total += val
                         per_day[d] += val
         avg = total / len(data.days) if data.days else 0
-        ws_teachers.append([t, int(total), data.teacher_weekly_cap, round(avg, 1)] + [int(per_day[d]) for d in data.days])
+        ws_teachers.append([t, int(total), round(avg, 1)] + [int(per_day[d]) for d in data.days])
     for cell in ws_teachers[1]:
         cell.font = Font(bold=True)
 

--- a/src/input_data.py
+++ b/src/input_data.py
@@ -3,7 +3,7 @@
 # Единый контейнер входных данных и весов для задачи составления школьного расписания.
 # Добавлены поля и веса, которые используются улучшенной моделью CP-SAT:
 #  - Лексикографическая оптимизация (use_lexico, lexico_primary)
-#  - Индивидуальные лимиты / запреты (teacher_daily_cap, teacher_forbidden_slots и т.п.)
+#  - Индивидуальные запреты (teacher_forbidden_slots и т.п.)
 #  - Часто используемые "политики" (must_sync_split_subjects)
 #  - Параметры решателя: num_search_workers, random_seed, time_limit_s, relative_gap_limit
 # -----------------------------------------------------------------------------
@@ -76,8 +76,6 @@ class InputData:
 
     Ограничения/предпочтения (жёсткие и мягкие):
       - days_off: выходные/недоступные дни учителей (на уровне дня)
-      - teacher_weekly_cap: лимит НЕДЕЛЬНОЙ нагрузки учителя (скаляр или {teacher: cap})
-      - teacher_daily_cap: лимит ДНЕВНОЙ нагрузки учителя (скаляр или {teacher: cap})
       - class_daily_cap: лимит уроков в день для класса (скаляр или {class: cap})
       - teacher_forbidden_slots: явные запреты слотов для преподавателей
       - forbidden_slots: жёсткий запрет проводить ЛЮБОЙ урок у класса в указанном слоте
@@ -114,12 +112,6 @@ class InputData:
 
     # --- Недоступные дни / лимиты / запреты ---
     days_off: DaysOff = field(default_factory=dict)
-
-    # Лимит недельной нагрузки на преподавателя (скаляр для всех или словарь по преподавателям)
-    teacher_weekly_cap: ScalarOrPerEntityInt = 35
-
-    # Лимит дневной нагрузки на преподавателя (скаляр или словарь). По умолчанию нет ограничения.
-    teacher_daily_cap: Optional[ScalarOrPerEntityInt] = None
 
     # Лимит уроков в день на класс (скаляр или словарь). По умолчанию нет ограничения.
     class_daily_cap: Optional[ScalarOrPerEntityInt] = None

--- a/src/print_schedule.py
+++ b/src/print_schedule.py
@@ -3,8 +3,6 @@
 Pretty-printers and Excel exporters for timetables.
 
 Исправления:
-- Корректная обработка teacher_weekly_cap, который теперь может быть числом ИЛИ словарём {teacher: cap}.
-- В учительской сводке "Лимит" берётся персонально, если передан словарь.
 - В классной сводке проверка перегруза опирается на class_daily_cap (если задан), иначе остаётся исторический порог >7.
 """
 
@@ -217,7 +215,7 @@ def export_full_schedule_to_excel(
     ws_summary.append([])
     ws_summary.append(["Сводка по учителям"])
     ws_summary.cell(ws_summary.max_row, 1).font = bold_font
-    header = ["Учитель", "Всего", "Лимит/нед", "Сред./день", "Окна"] + data.days + ["Предупреждения"]
+    header = ["Учитель", "Всего", "Сред./день", "Окна"] + data.days + ["Предупреждения"]
     ws_summary.append(header)
 
     for t in data.teachers:
@@ -234,12 +232,6 @@ def export_full_schedule_to_excel(
                 total_windows += (last - first + 1) - len(busy)
 
         warnings = []
-        # ЛИМИТ НЕДЕЛЬНОЙ НАГРУЗКИ: число или словарь по учителям
-        weekly_cap = _get_cap_value(getattr(data, "teacher_weekly_cap", None), t)
-        weekly_cap_display = weekly_cap if weekly_cap is not None else "—"
-        if weekly_cap is not None and total > weekly_cap:
-            warnings.append(f"Перегруз! ({total}/{weekly_cap})")
-
         # Дополнительно можно предупредить об излишних окнах (условный порог)
         if total_windows > 5:
             warnings.append("Окна > 5")
@@ -247,7 +239,6 @@ def export_full_schedule_to_excel(
         row = [
             get_teacher_name(t),
             total,
-            weekly_cap_display,
             f"{avg:.1f}",
             total_windows
         ] + [per_day[d] for d in data.days] + [", ".join(warnings)]

--- a/src/rasp_data.py
+++ b/src/rasp_data.py
@@ -1,8 +1,8 @@
 # rasp_data.py
 # -----------------------------------------------------------------------------
 # Тестовые данные для задачи составления школьного расписания.
-# Обновлено: добавлены поля, используемые улучшенной моделью (teacher_daily_cap,
-# class_daily_cap, teacher_forbidden_slots, must_sync_split_subjects и др.)
+# Обновлено: добавлены поля, используемые улучшенной моделью (class_daily_cap,
+# teacher_forbidden_slots, must_sync_split_subjects и др.)
 # -----------------------------------------------------------------------------
 
 from input_data import InputData
@@ -95,25 +95,7 @@ def create_manual_data() -> InputData:
     teacher_slot_weight = {("Petrov", "Tue", 1): 8.0}
     class_subject_day_weight = {("5B", "math", "Mon"): 6.0}
 
-    # Лимиты недельной нагрузки учителей (персонально; можно оставить скаляр по умолчанию = 35)
-    teacher_weekly_cap = {
-        "Ivanov": 10,   # всего 4 урока math в неделю
-        "Petrov": 12,   # всего 4 урока cs (по подгруппам)
-        "Sidorov": 6,   # всего 2 урока eng (g1 * 2 класса)
-        "Nikolaev": 6,  # всего 2 урока eng (g2 * 2 класса)
-        "Smirnov": 10,  # всего 4 урока labor (по подгруппам)
-    }
-
-    # Лимит уроков в день:
-    #  - для преподавателей (0/None — не ограничиваем). Здесь задаём словарь для примера.
-    teacher_daily_cap = {
-        "Ivanov": 4,
-        "Petrov": 4,
-        "Sidorov": 4,
-        "Nikolaev": 4,
-        "Smirnov": 4,
-    }
-    #  - для классов (скаляр или словарь)
+    # Лимит уроков в день для классов (скаляр или словарь)
     class_daily_cap = {"5A": 6, "5B": 6}
 
     # Запрещённые слоты для конкретных преподавателей
@@ -164,8 +146,6 @@ def create_manual_data() -> InputData:
         class_subject_day_weight=class_subject_day_weight,
 
         # Лимиты / запреты
-        teacher_weekly_cap=teacher_weekly_cap,
-        teacher_daily_cap=teacher_daily_cap,
         class_daily_cap=class_daily_cap,
         teacher_forbidden_slots=teacher_forbidden_slots,
 


### PR DESCRIPTION
## Summary
- drop `teacher_weekly_cap` and `teacher_daily_cap` from the input data model and sample data
- simplify solver and exports by removing teacher load limit logic

## Testing
- `python -m py_compile src/input_data.py src/rasp_or_tools.py src/print_schedule.py src/rasp_data.py src/export_all_to_excel.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc727b0fe48325acc9a8b13203bcc5