### PR TITLE
Remove class_daily_cap variable and constraints

### DIFF
--- a/src/input_data.py
+++ b/src/input_data.py
@@ -76,7 +76,6 @@ class InputData:
 
     Ограничения/предпочтения (жёсткие и мягкие):
       - days_off: выходные/недоступные дни учителей (на уровне дня)
-      - class_daily_cap: лимит уроков в день для класса (скаляр или {class: cap})
       - teacher_forbidden_slots: явные запреты слотов для преподавателей
       - forbidden_slots: жёсткий запрет проводить ЛЮБОЙ урок у класса в указанном слоте
       - class_slot_weight / teacher_slot_weight / class_subject_day_weight: пользовательские «мягкие» предпочтения
@@ -112,9 +111,6 @@ class InputData:
 
     # --- Недоступные дни / лимиты / запреты ---
     days_off: DaysOff = field(default_factory=dict)
-
-    # Лимит уроков в день на класс (скаляр или словарь). По умолчанию нет ограничения.
-    class_daily_cap: Optional[ScalarOrPerEntityInt] = None
 
     # Явные запреты слотов у преподавателей: teacher -> [(day, period), ...]
     teacher_forbidden_slots: TeacherForbiddenSlots = field(default_factory=dict)

--- a/src/rasp_data.py
+++ b/src/rasp_data.py
@@ -1,8 +1,8 @@
 # rasp_data.py
 # -----------------------------------------------------------------------------
 # Тестовые данные для задачи составления школьного расписания.
-# Обновлено: добавлены поля, используемые улучшенной моделью (class_daily_cap,
-# teacher_forbidden_slots, must_sync_split_subjects и др.)
+# Обновлено: добавлены поля, используемые улучшенной моделью (teacher_forbidden_slots,
+# must_sync_split_subjects и др.)
 # -----------------------------------------------------------------------------
 
 from input_data import InputData
@@ -95,9 +95,6 @@ def create_manual_data() -> InputData:
     teacher_slot_weight = {("Petrov", "Tue", 1): 8.0}
     class_subject_day_weight = {("5B", "math", "Mon"): 6.0}
 
-    # Лимит уроков в день для классов (скаляр или словарь)
-    class_daily_cap = {"5A": 6, "5B": 6}
-
     # Запрещённые слоты для конкретных преподавателей
     teacher_forbidden_slots = {
         "Petrov": [("Tue", 1)],     # кроме days_off, ещё и «Вт‑1» нельзя
@@ -146,7 +143,6 @@ def create_manual_data() -> InputData:
         class_subject_day_weight=class_subject_day_weight,
 
         # Лимиты / запреты
-        class_daily_cap=class_daily_cap,
         teacher_forbidden_slots=teacher_forbidden_slots,
 
         # Частые «политики»


### PR DESCRIPTION
## Summary
- drop `class_daily_cap` field from input data and sample data
- remove daily class cap constraint from scheduler
- simplify schedule printing to always warn on >7 lessons per day

## Testing
- `pytest`
- `python -m py_compile src/input_data.py src/rasp_or_tools.py src/print_schedule.py src/rasp_data.py && echo 'py_compile ok'`


------
https://chatgpt.com/codex/tasks/task_e_68bc760cbf388325ba7b2db29d5ae038