### PR TITLE
Restore split subject compatibility pairs

### DIFF
--- a/src/access_loader.py
+++ b/src/access_loader.py
@@ -167,6 +167,18 @@ def load_data_from_access(db_path: str) -> InputData:
     # class_subject_day_weight = {("5B", "math", "Mon"): 6.0}
     class_subject_day_weight = get_dict("v_class_subject_day_weight", ["ClassName", "SubjectName", "day_of_week"], "weight",value_is_numeric=True)
 
+    # Совместимость пар
+    # compatible_pairs = {('cs', 'eng')}
+    df_compat = pd.read_sql("SELECT * FROM v_сompatible_pairs", engine)
+    if not df_compat.empty:
+        # Санитайзим имена предметов в обеих колонках
+        for col in df_compat.columns:
+            if df_compat[col].dtype == 'object':
+                df_compat[col] = df_compat[col].str.strip().apply(_sanitize_lp_name)
+    compatible_pairs = {tuple(sorted(pair)) for pair in df_compat.to_records(index=False)}
+    # pprint(compatible_pairs)
+    # return
+
     # days=["Mon", "Tue", "Wed", "Thu", "Fri"]
     days = get_list("сп_days_of_week", "day_of_week")
     # pprint(days)
@@ -186,6 +198,7 @@ def load_data_from_access(db_path: str) -> InputData:
         class_slot_weight=class_slot_weight,
         teacher_slot_weight=teacher_slot_weight,
         class_subject_day_weight=class_subject_day_weight,
+        compatible_pairs=compatible_pairs,
         paired_subjects=paired_subjects
     )
 

--- a/src/data_exporter.py
+++ b/src/data_exporter.py
@@ -44,7 +44,8 @@ def print_data_for_manual_creation(data: InputData):
     pprint(data.teacher_slot_weight)
     print("class_subject_day_weight = \\")
     pprint(data.class_subject_day_weight)
-
+    print("\n# --- Совместимости ---")
+    print(f"compatible_pairs = {data.compatible_pairs!r}")
     print("-" * 80)
     print("# Не забудьте в конце функции вернуть объект: return InputData(...)")
 

--- a/src/generate_static_data_file.py
+++ b/src/generate_static_data_file.py
@@ -22,6 +22,7 @@ def generate_function_string(data: InputData) -> str:
     class_subject_day_weight_str = pprint.pformat(data.class_subject_day_weight, indent=4, width=120)
     forbidden_slots_str = pprint.pformat(data.forbidden_slots, indent=4, width=120)
     split_subjects_str = pprint.pformat(data.split_subjects, indent=4, width=120)
+    compatible_pairs_str = pprint.pformat(data.compatible_pairs, indent=4, width=120)
     paired_subjects_str = pprint.pformat(data.paired_subjects, indent=4, width=120)
 
     # Собираем итоговый код функции в виде многострочной f-строки
@@ -63,6 +64,9 @@ def create_timetable_data() -> InputData:
     teacher_slot_weight = {teacher_slot_weight_str}
     class_subject_day_weight = {class_subject_day_weight_str}
 
+    # --- Совместимости ---
+    compatible_pairs = {compatible_pairs_str}
+
     # --- Спаривание ---
     paired_subjects = {paired_subjects_str}
 
@@ -83,6 +87,7 @@ def create_timetable_data() -> InputData:
         class_slot_weight=class_slot_weight,
         teacher_slot_weight=teacher_slot_weight,
         class_subject_day_weight=class_subject_day_weight,
+        compatible_pairs=compatible_pairs,
         paired_subjects=paired_subjects
     )
 """

--- a/src/input_data.py
+++ b/src/input_data.py
@@ -80,6 +80,11 @@ class InputData:
       - forbidden_slots: жёсткий запрет проводить ЛЮБОЙ урок у класса в указанном слоте
       - class_slot_weight / teacher_slot_weight / class_subject_day_weight: пользовательские «мягкие» предпочтения
 
+    Совместимость подгрупп:
+      - compatible_pairs: множество разрешённых НЕУПОРЯДОЧЕННЫХ пар (s1, s2) split‑предметов,
+        которые могут идти одновременно в одном классе и слоте.
+        Хранить как tuple(sorted((s1, s2))). Разрешение одного и того же предмета параллельно — пара ("eng","eng").
+
     Дополнительные «политики»:
       - paired_subjects: предметы, которые желательно ставить парами (два подряд)
       - must_sync_split_subjects: сплит‑предметы, требующие одновременности подгрупп
@@ -117,6 +122,10 @@ class InputData:
     class_slot_weight: ClassSlotWeight = field(default_factory=dict)
     teacher_slot_weight: TeacherSlotWeight = field(default_factory=dict)
     class_subject_day_weight: ClassSubjectDayWeight = field(default_factory=dict)
+
+    # --- Совместимости split‑предметов ---
+    # Храним как отсортированные пары, напр.: {("eng","eng"), ("cs","eng"), ("labor","labor")}
+    compatible_pairs: Set[Tuple[str, str]] = field(default_factory=set)
 
     # --- Предпочтения по «спариванию» ---
     # Предметы, которые желательно ставить по 2 урока подряд

--- a/src/rasp_data.py
+++ b/src/rasp_data.py
@@ -8,6 +8,29 @@
 from input_data import InputData
 
 
+def make_default_compat():
+    """Разрешённые пары одновременных split‑предметов (для разных предметов).
+
+    Логика совместимости применяется только к ПАРАМ предметов (s1 != s2):
+    внутри одного слота класс может вести два РАЗНЫХ split‑предмета для разных подгрупп
+    только если такая пара разрешена. Пары вида ("eng","eng") не нужны, так как
+    проверка делается только для разных предметов.
+    """
+    allowed = set()
+
+    def add(a, b):
+        allowed.add(tuple(sorted((a, b))))
+
+    # Разрешаем одновременно вести "cs" и "eng" (например, g1: cs; g2: eng)
+    add("cs", "eng")
+
+    # Пример: можем дополнить и другими парами при необходимости:
+    # add("labor", "eng")
+    # add("labor", "cs")
+
+    return allowed
+
+
 def create_manual_data() -> InputData:
     # --- Основные множества ---
     days = ["Mon", "Tue", "Wed", "Thu", "Fri"]
@@ -118,6 +141,9 @@ def create_manual_data() -> InputData:
 
         # Лимиты / запреты
         teacher_forbidden_slots=teacher_forbidden_slots,
+
+        # Совместимости split‑предметов
+        compatible_pairs=make_default_compat(),
 
         # Частые «политики»
         must_sync_split_subjects=must_sync_split_subjects,

--- a/src/rasp_data_generated.py
+++ b/src/rasp_data_generated.py
@@ -796,6 +796,9 @@ def create_timetable_data() -> InputData:
     teacher_slot_weight = {('Vac_2', 'Tue', 1): 8}
     class_subject_day_weight = {('5A', 'Geog', 'Mon'): 6}
 
+    # --- Совместимости ---
+    compatible_pairs = {('CS', 'Eng')}
+
     # --- Спаривание ---
     paired_subjects = {'Trud'}
 
@@ -816,5 +819,6 @@ def create_timetable_data() -> InputData:
         class_slot_weight=class_slot_weight,
         teacher_slot_weight=teacher_slot_weight,
         class_subject_day_weight=class_subject_day_weight,
+        compatible_pairs=compatible_pairs,
         paired_subjects=paired_subjects
     )

--- a/src/rasp_or_tools.py
+++ b/src/rasp_or_tools.py
@@ -236,6 +236,17 @@ def build_and_solve_with_or_tools(
         else:
             model.Add(is_subj_taught[c, s, d, p] == 0)
 
+    # Несовместимые пары сплит‑предметов: не могут идти одновременно у класса
+    split_list = sorted(list(splitS))
+    for c, d, p in itertools.product(C, D, P):
+        for s1, s2 in itertools.combinations(split_list, 2):
+            pair = tuple(sorted((s1, s2)))
+            if pair not in getattr(data, 'compatible_pairs', set()):
+                model.AddBoolOr([
+                    is_subj_taught[c, s1, d, p].Not(),
+                    is_subj_taught[c, s2, d, p].Not(),
+                ])
+
     # ------------------------- 3.3) ДОПОЛНИТЕЛЬНЫЕ ОПЦИИ (НЕОБЯЗ.) -------------------------
 
     # (A) Синхронность подгрупп для некоторых сплит‑предметов


### PR DESCRIPTION
## Summary
- reintroduce `compatible_pairs` to describe allowed simultaneous split-subject combinations
- enforce incompatibilities in solver and load pairs from data sources

## Testing
- `python -m py_compile src/input_data.py src/rasp_or_tools.py src/access_loader.py src/data_exporter.py src/generate_static_data_file.py src/rasp_data.py src/rasp_data_generated.py`
- `python src/rasp_or_tools.py` *(fails: [unixODBC][Driver Manager]Can't open lib 'Microsoft Access Driver (*.mdb, *.accdb)' : file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfe258d048325b3cf8660c2059b10