### PR TITLE
Implement elementary school scheduling rules

### DIFF
--- a/src/rasp_data.py
+++ b/src/rasp_data.py
@@ -5,7 +5,7 @@
 # must_sync_split_subjects и др.)
 # -----------------------------------------------------------------------------
 
-from input_data import InputData
+from input_data import InputData, ClassInfo
 
 
 def make_default_compat():
@@ -35,7 +35,10 @@ def create_manual_data() -> InputData:
     # --- Основные множества ---
     days = ["Mon", "Tue", "Wed", "Thu", "Fri"]
     periods = list(range(1, 8))  # 1..7
-    classes = ["5A", "5B"]
+    classes = [
+        ClassInfo(name="5A", grade=5),
+        ClassInfo(name="5B", grade=5),
+    ]
     subjects = ["math", "cs", "eng", "labor"]
     teachers = ["Ivanov", "Petrov", "Sidorov", "Nikolaev", "Smirnov"]
 
@@ -141,6 +144,7 @@ def create_manual_data() -> InputData:
 
         # Лимиты / запреты
         teacher_forbidden_slots=teacher_forbidden_slots,
+        grade_subject_max_consecutive_days={5: {"PE": 2}},
 
         # Совместимости split‑предметов
         compatible_pairs=make_default_compat(),


### PR DESCRIPTION
## Summary
- structure classes as objects with grade and per-subject consecutive-day limits
- enforce per-class subject-day spacing in OR-Tools model
- update sample data to provide class metadata
- support grade-based subject consecutive-day limits

## Testing
- `python -m py_compile src/input_data.py src/rasp_or_tools.py src/rasp_data.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be5cfbe9ac83259d3f8f148859d2c6