### PR TITLE
Expand timetable sample with additional data

### DIFF
--- a/src/rasp_data.py
+++ b/src/rasp_data.py
@@ -1,19 +1,28 @@
-# rasp_data.py
-# -----------------------------------------------------------------------------
-# Comprehensive test data for the school timetable problem.
-# Every field from InputData and OptimizationWeights is filled explicitly so that
-# the file can serve as a complete example for experiments and testing.
-# -----------------------------------------------------------------------------
+"""Sample data set for the timetable model.
+
+This module provides a small yet fully populated :class:`InputData` instance
+that can be used for experiments and manual testing.  Every collection in the
+data structure is filled explicitly so the file doubles as comprehensive
+documentation of the expected input format.
+"""
 
 from input_data import ClassInfo, InputData, OptimizationWeights
 
 
 def make_default_compat() -> set[tuple[str, str]]:
-    """Return a set of allowed pairs of concurrent split subjects."""
+    """Return allowed pairs of concurrent split subjects.
+
+    Some split subjects can take place in parallel for different subgroups of
+    the same class (e.g. English for one subgroup and Computer Science for the
+    other).  The solver needs the set of such compatible pairs expressed as
+    ordered tuples with lexicographically sorted subject names.
+    """
 
     allowed: set[tuple[str, str]] = set()
 
     def add(subj_a: str, subj_b: str) -> None:
+        """Add an unordered pair of subjects to the compatibility set."""
+
         allowed.add(tuple(sorted((subj_a, subj_b))))
 
     # Разрешаем вести эти split‑предметы параллельно в одном классе и слоте
@@ -25,27 +34,76 @@ def make_default_compat() -> set[tuple[str, str]]:
 
 
 def create_manual_data() -> InputData:
-    """Create a small InputData instance with all fields populated."""
+    """Create a fully populated :class:`InputData` instance.
 
-    # --- Базовые множества ---
+    The function below enumerates every piece of data expected by the solver:
+    base sets, lesson plans, teacher assignments and a selection of scheduling
+    policies.  It is intentionally verbose so that the structure of the
+    :class:`InputData` dataclass is clear from a single file.
+    """
+
+    # ------------------------------------------------------------------
+    # Базовые множества
+    # ------------------------------------------------------------------
+    # Пять учебных дней и семь уроков в каждом дне.
     days = ["Mon", "Tue", "Wed", "Thu", "Fri"]
     periods = list(range(1, 8))  # 1..7
-    classes = [ClassInfo(name="5A", grade=5), ClassInfo(name="5B", grade=5)]
-    subjects = ["math", "cs", "eng", "labor", "PE"]
-    teachers = ["Ivanov", "Petrov", "Sidorov", "Nikolaev", "Smirnov"]
 
-    # --- Подгруппы ---
+    # Три класса: две пятых параллели и один класс начальной школы.
+    classes = [
+        ClassInfo(name="5A", grade=5),
+        ClassInfo(name="5B", grade=5),
+        ClassInfo(name="2A", grade=2),
+    ]
+
+    # Перечень изучаемых предметов. История и музыка добавлены как примеры
+    # обычных (неподгрупповых) дисциплин.
+    subjects = [
+        "math",
+        "cs",
+        "eng",
+        "labor",
+        "PE",
+        "history",
+        "music",
+    ]
+
+    # Список всех преподавателей, задействованных в примере.
+    teachers = [
+        "Ivanov",
+        "Petrov",
+        "Sidorov",
+        "Nikolaev",
+        "Smirnov",
+        "Kuznetsov",  # history
+        "Orlova",     # music
+    ]
+
+    # ------------------------------------------------------------------
+    # Подгруппы
+    # ------------------------------------------------------------------
+    # Английский, информатика и труд ведутся по подгруппам, поэтому для них
+    # требуется указывать часы и преподавателей отдельно для каждой подгруппы.
     split_subjects = {"eng", "cs", "labor"}
     subgroup_ids = [1, 2]
 
-    # --- Учебные планы ---
+    # ------------------------------------------------------------------
+    # Учебные планы
+    # ------------------------------------------------------------------
+    # plan_hours описывает часы для предметов без деления на подгруппы, а
+    # subgroup_plan_hours — отдельно для каждой подгруппы.
     plan_hours = {
         ("5A", "math"): 2,
         ("5B", "math"): 2,
         ("5A", "PE"): 1,
         ("5B", "PE"): 1,
+        ("5A", "history"): 1,
+        ("5B", "history"): 1,
+        ("5A", "music"): 1,
+        ("5B", "music"): 1,
     }
     subgroup_plan_hours = {
+        # 5-е классы
         ("5A", "eng", 1): 1,
         ("5A", "eng", 2): 1,
         ("5A", "cs", 1): 1,
@@ -58,14 +116,23 @@ def create_manual_data() -> InputData:
         ("5B", "cs", 2): 1,
         ("5B", "labor", 1): 1,
         ("5B", "labor", 2): 1,
+        # Класс 2A получает две части английского — по одному часу на подгруппу
+        ("2A", "eng", 1): 1,
+        ("2A", "eng", 2): 1,
     }
 
-    # --- Закрепления преподавателей ---
+    # ------------------------------------------------------------------
+    # Закрепления преподавателей
+    # ------------------------------------------------------------------
     assigned_teacher = {
         ("5A", "math"): "Ivanov",
         ("5B", "math"): "Ivanov",
         ("5A", "PE"): "Smirnov",
         ("5B", "PE"): "Smirnov",
+        ("5A", "history"): "Kuznetsov",
+        ("5B", "history"): "Kuznetsov",
+        ("5A", "music"): "Orlova",
+        ("5B", "music"): "Orlova",
     }
     subgroup_assigned_teacher = {
         ("5A", "eng", 1): "Sidorov",
@@ -80,9 +147,14 @@ def create_manual_data() -> InputData:
         ("5B", "cs", 2): "Petrov",
         ("5B", "labor", 1): "Smirnov",
         ("5B", "labor", 2): "Smirnov",
+        # Английский у второго класса
+        ("2A", "eng", 1): "Sidorov",
+        ("2A", "eng", 2): "Nikolaev",
     }
 
-    # --- Доступность и ограничения ---
+    # ------------------------------------------------------------------
+    # Доступность и ограничения
+    # ------------------------------------------------------------------
     days_off = {"Petrov": {"Mon"}}
     teacher_forbidden_slots = {
         "Petrov": [("Tue", 1)],
@@ -90,8 +162,10 @@ def create_manual_data() -> InputData:
     }
     forbidden_slots = {("5A", "Mon", 1)}
 
-    # --- Политики и предпочтения ---
-    grade_max_lessons_per_day = {5: 6}
+    # ------------------------------------------------------------------
+    # Политики и предпочтения
+    # ------------------------------------------------------------------
+    grade_max_lessons_per_day = {5: 6, 2: 4}
     subjects_not_last_lesson = {"math", "eng"}
     elementary_english_periods = {2, 3, 4}
     grade_subject_max_consecutive_days = {5: {"PE": 2}}
@@ -103,7 +177,7 @@ def create_manual_data() -> InputData:
     class_subject_day_weight = {("5B", "math", "Mon"): 6.0}
     compatible_pairs = make_default_compat()
     paired_subjects = {"math"}
-    must_sync_split_subjects = {"eng"}
+    must_sync_split_subjects = {"eng", "cs"}
 
     return InputData(
         days=days,


### PR DESCRIPTION
## Summary
- flesh out sample timetable with history and music subjects and corresponding teachers
- introduce class 2A with two weekly English hours
- document dataset more thoroughly and sync English and CS split groups

## Testing
- `PYTHONPATH=src python -m py_compile src/input_data.py src/rasp_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68bec8547cfc8325a9a91eec0db24524