### PR TITLE
feat: support grade-specific last-lesson restrictions

### DIFF
--- a/src/input_data.py
+++ b/src/input_data.py
@@ -96,8 +96,8 @@ class InputData:
       - must_sync_split_subjects: сплит‑предметы, требующие одновременности подгрупп
       - grade_max_lessons_per_day: дневные ограничения по числу уроков
           Пример: {2: 4, 3: 5, 4: 5}
-      - subjects_not_last_lesson: предметы, которые не могут быть последними в дне
-          Пример: {"math", "physics"}
+      - subjects_not_last_lesson: предметы, которые не могут быть последними в дне по параллелям
+          Пример: {5: {"math"}, 7: {"math", "physics"}}
       - elementary_english_periods: допустимые номера уроков для английского в начальной школе
           Пример: {2, 3, 4}
       - grade_subject_max_consecutive_days: ограничения по макс. подряд идущим дням для предметов по параллелям
@@ -139,8 +139,10 @@ class InputData:
     # --- Дополнительные данные для школьных правил ---
     # Максимальное число уроков в день по параллели, например {2: 4, 3: 5, 4: 5}
     grade_max_lessons_per_day: Dict[int, int] = field(default_factory=lambda: {2: 4, 3: 5, 4: 5})
-    # Предметы, которые не могут быть последним уроком дня, например {"math", "physics"}
-    subjects_not_last_lesson: Set[str] = field(default_factory=lambda: {"math", "physics"})
+    # Предметы, которые не могут быть последним уроком дня по параллелям, например {5: {"math"}}
+    subjects_not_last_lesson: Dict[int, Set[str]] = field(
+        default_factory=lambda: {g: {"math", "physics"} for g in range(1, 9)}
+    )
     # Разрешённые номера уроков для английского языка в начальной школе, например {2, 3, 4}
     elementary_english_periods: Set[int] = field(default_factory=lambda: {2, 3, 4})
     # Максимальное число подряд идущих дней с предметом по параллели, например {3: {"PE": 2}}

--- a/src/rasp_data.py
+++ b/src/rasp_data.py
@@ -166,7 +166,7 @@ def create_manual_data() -> InputData:
     # Политики и предпочтения
     # ------------------------------------------------------------------
     grade_max_lessons_per_day = {5: 6, 2: 4}
-    subjects_not_last_lesson = {"math", "eng"}
+    subjects_not_last_lesson = {2: {"math", "eng"}, 5: {"math"}}
     elementary_english_periods = {2, 3, 4}
     grade_subject_max_consecutive_days = {5: {"PE": 2}}
     class_slot_weight = {

--- a/src/rasp_or_tools.py
+++ b/src/rasp_or_tools.py
@@ -263,7 +263,7 @@ def build_and_solve_with_or_tools(
 
     # (6) Дополнительные ограничения для начальной школы и общие правила
     grade_max = getattr(data, 'grade_max_lessons_per_day', {})
-    subjects_not_last = set(getattr(data, 'subjects_not_last_lesson', set()))
+    subjects_not_last_map = getattr(data, 'subjects_not_last_lesson', {})
     english_periods = getattr(data, 'elementary_english_periods', {2, 3, 4})
     last_period = max(P) if P else 0
 
@@ -276,11 +276,12 @@ def build_and_solve_with_or_tools(
                 if g in grade_max:
                     model.Add(day_load <= grade_max[g])
 
-    # (6b) Математика и физика не могут быть последним уроком (2-8 классы)
+    # (6b) Предметы, запрещённые последними уроками по параллелям
     for c in C:
         g = class_grades.get(c)
-        if g is not None and 2 <= g <= 8:
-            for s in subjects_not_last:
+        if g is not None:
+            banned_subjects = subjects_not_last_map.get(g, set())
+            for s in banned_subjects:
                 if s in splitS:
                     for g_id in G:
                         for d in D:


### PR DESCRIPTION
## Summary
- allow configuring subjects that cannot be last per grade
- update sample data and solver to respect per-grade rules

## Testing
- `pytest -q`
- `python src/rasp_or_tools.py` *(fails: solution infeasible)*

------
https://chatgpt.com/codex/tasks/task_e_68becb3c4c90832585edb8b5cd4d6a61